### PR TITLE
Print error messages returned by the server in the Windows PowerShell script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -20,28 +20,28 @@ try {
     [System.IO.Compression.ZipFile]::CreateFromDirectory($Src, $Dest, [System.IO.Compression.CompressionLevel]::Optimal, $false)
 } catch {
     echo "Unable to create a ZIP file. Aborting."
-	echo $_.Exception.GetType().FullName, $_.Exception.Message
+    echo $_.Exception.GetType().FullName, $_.Exception.Message
     Exit
 }
 
 # Upload the file
 try {
-	$OldEAP = $ErrorActionPreference
-	$ErrorActionPreference = 'SilentlyContinue'
+    $OldEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
     $result = Invoke-RestMethod -Uri "https://happening.im/plugin/$($Args[0])" -InFile $Dest -Method POST
-	$ErrorActionPreference = $OldEAP
-	# Print success result
-	echo $result
+    $ErrorActionPreference = $OldEAP
+    # Print success result
+    echo $result
 } catch [Exception] {
-	echo ">>> Something went wrong with submitting the plugin to Happening:"
-	# Print the exception message (includes the HTTP status code)
-	echo $_.Exception.Message
-	# Print the body of the server response (includes the error message from Happening)
-	$result = $_.Exception.Response.GetResponseStream()
-	$reader = New-Object System.IO.StreamReader($result)
-	$reader.BaseStream.Position = 0
-	$reader.DiscardBufferedData()
-	$responseBody = $reader.ReadToEnd();
-	echo $responseBody
-	Exit
+    echo ">>> Something went wrong with submitting the plugin to Happening:"
+    # Print the exception message (includes the HTTP status code)
+    echo $_.Exception.Message
+    # Print the body of the server response (includes the error message from Happening)
+    $result = $_.Exception.Response.GetResponseStream()
+    $reader = New-Object System.IO.StreamReader($result)
+    $reader.BaseStream.Position = 0
+    $reader.DiscardBufferedData()
+    $responseBody = $reader.ReadToEnd();
+    echo $responseBody
+    Exit
 }


### PR DESCRIPTION
This improved version changes the Windows PowerShell script to print the result that the Happening server returns when deploying a plugin fails. Previously it would only print that the upload of the ZIP file failed, which does not help with debugging. It will also print an exception when the zip file creation does not work.
